### PR TITLE
Adding lifetime options

### DIFF
--- a/src/Mapr/MapAttribute.cs
+++ b/src/Mapr/MapAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Mapr;
+
+/// <summary>
+/// Represents an attribute that can be placed on map classes to control their behavior
+/// and registration.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class MapAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets the lifetime for the map. Determining how it will be registered in the
+    /// DI container. The default is <see cref="MapLifetime.Transient"/>.
+    /// </summary>
+    public MapLifetime Lifetime { get; set; } = MapLifetime.Transient;
+}
+
+/// <summary>
+/// Represents the different lifetimes that can be used to register a map.
+/// </summary>
+public enum MapLifetime
+{
+    /// <summary>
+    /// Registers the map as a singleton.
+    /// </summary>
+    Singleton,
+    
+    /// <summary>
+    /// Registers the map as a transient.
+    /// </summary>
+    Transient
+}

--- a/src/Mapr/MapLocator.cs
+++ b/src/Mapr/MapLocator.cs
@@ -25,7 +25,9 @@ public class MapLocator : IMapLocator
         try
         {
             if (_mapFactory(mapType) is not IMap<TSource, TDestination> typeMap)
+            {
                 throw new MapNotFoundException(mapType);
+            }
 
             return typeMap;
         }

--- a/tests/Mapr.DependencyInjection.Tests/MapperConfigTests.cs
+++ b/tests/Mapr.DependencyInjection.Tests/MapperConfigTests.cs
@@ -14,12 +14,24 @@ public class MapperConfigTests
         serviceCollection.AddMapr(_ => { });
 
         serviceCollection.Should()
-            .Contain(s => s.ServiceType == typeof(IMapper) && s.ImplementationType == typeof(Mapper));
+            .Contain(
+                s => s.ServiceType == typeof(IMapper) && 
+                     s.ImplementationType == typeof(Mapper) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
 
-        serviceCollection.Should().Contain(
-            s => s.ServiceType == typeof(IMapLocator) && s.ImplementationType == typeof(MapLocator));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ServiceType == typeof(IMapLocator) && 
+                     s.ImplementationType == typeof(MapLocator) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
 
-        serviceCollection.Should().Contain(s => s.ServiceType == typeof(MapFactory));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ServiceType == typeof(MapFactory) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
     }
 
     [Fact]
@@ -32,11 +44,26 @@ public class MapperConfigTests
             config.Scan(typeof(TestMap).Assembly);
         });
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<string, int>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<string, int>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<int, string>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<int, string>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
+        
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestSingletonMap) && 
+                     s.ServiceType == typeof(IMap<string, string>) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
     }
 
     [Fact]
@@ -49,15 +76,30 @@ public class MapperConfigTests
             config.Scan<TestMap>();
         });
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<string, int>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<string, int>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<int, string>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<int, string>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
+        
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestSingletonMap) && 
+                     s.ServiceType == typeof(IMap<string, string>) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
     }
 
     [Fact]
-    public void AddMap_ShouldAppMap()
+    public void AddMap_ShouldAddMap()
     {
         var serviceCollection = new ServiceCollection();
 
@@ -67,10 +109,36 @@ public class MapperConfigTests
                 .AddMap<int, string, TestMap>();
         });
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<string, int>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<string, int>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
 
-        serviceCollection.Should().Contain(
-            s => s.ImplementationType == typeof(TestMap) && s.ServiceType == typeof(IMap<int, string>));
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestMap) && 
+                     s.ServiceType == typeof(IMap<int, string>) &&
+                     s.Lifetime == ServiceLifetime.Transient
+            );
+    }
+    
+    [Fact]
+    public void AddMap_ShouldAddSingletonMap_WhenAttributeIsPresent()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddMapr(config =>
+        {
+            config.AddMap<string, string, TestSingletonMap>();
+        });
+
+        serviceCollection.Should()
+            .Contain(
+                s => s.ImplementationType == typeof(TestSingletonMap) && 
+                     s.ServiceType == typeof(IMap<string, string>) &&
+                     s.Lifetime == ServiceLifetime.Singleton
+            );
     }
 }

--- a/tests/Mapr.DependencyInjection.Tests/TestSingletonMap.cs
+++ b/tests/Mapr.DependencyInjection.Tests/TestSingletonMap.cs
@@ -1,0 +1,11 @@
+﻿namespace Mapr.DependencyInjection.Tests;
+
+[Map(Lifetime = MapLifetime.Singleton)]
+public class TestSingletonMap: IMap<string, string>
+{
+    /// <inheritdoc />
+    public string Map(string source)
+    {
+        return source;
+    }
+}


### PR DESCRIPTION
Adding lifetime options for registering Maps with the DI container. No breaking changes in this PR, only the addition to configure how your Maps are registered (Singleton, or Transient). Registering Maps as Singleton drastically reduces the amount of memory allocations in the process of running a map through the mapper.

Registered as Transient and calling mapper over many iterations causes a lot of GC time and allocation
![image](https://user-images.githubusercontent.com/33334607/148574006-9a4e108c-4c18-4b20-b0cc-fc3b87776337.png)

Adding the `[Map(Lifetime = MapLifetime.Singleton)]` to the map now completely removes that allocation
![image](https://user-images.githubusercontent.com/33334607/148574217-19f5a2fa-3222-4143-b993-9651e35c13ae.png)

The default behaviour of the registration is still to register maps as `Transient`, but I would highly recommend keeping maps as *pure* and register them as `Singleton`.
